### PR TITLE
Add PWA for viewing shared URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Shared URL Viewer</title>
+  <link rel="manifest" href="manifest.webmanifest">
+</head>
+<body>
+  <h1>Shared URL</h1>
+  <p id="url">No URL shared.</p>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('sw.js');
+    }
+    const params = new URL(location.href).searchParams;
+    const sharedUrl = params.get('url') || params.get('text');
+    if (sharedUrl) {
+      const urlElem = document.getElementById('url');
+      const link = document.createElement('a');
+      link.href = sharedUrl;
+      link.textContent = sharedUrl;
+      urlElem.textContent = '';
+      urlElem.appendChild(link);
+    }
+  </script>
+</body>
+</html>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,16 @@
+{
+  "name": "Shared URL Viewer",
+  "short_name": "URL Viewer",
+  "start_url": "./",
+  "display": "standalone",
+  "share_target": {
+    "action": "./",
+    "method": "GET",
+    "enctype": "application/x-www-form-urlencoded",
+    "params": {
+      "url": "url",
+      "title": "title",
+      "text": "text"
+    }
+  }
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,29 @@
+const CACHE_NAME = 'url-viewer-v1';
+const ASSETS = [
+  './',
+  'index.html',
+  'manifest.webmanifest',
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      caches.match('index.html').then(resp => resp || fetch('index.html'))
+    );
+    return;
+  }
+  event.respondWith(
+    fetch(event.request).catch(() => caches.match(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- Create minimal PWA that shows URLs shared through Android's share target
- Add web manifest with share_target configuration
- Include service worker and icons for offline support
- Remove icon binaries and references so app works without binary assets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bed5668e988330ac366a5431f004dc